### PR TITLE
Resolve issue #20

### DIFF
--- a/lib/nagira/background_parse.rb
+++ b/lib/nagira/background_parse.rb
@@ -14,11 +14,14 @@ module Nagios
     #
     def initialize
       interval = [::DEFAULT[:ttl],1].max || nil
+      $use_inflight_status = false
+      $use_inflight_objects = false
       if interval && ::DEFAULT[:start_background_parser]
         puts "[#{Time.now}] Starting background parser thread with interval #{interval} sec"
         $bg = Thread.new {
           loop {
-            $nagios[:status].parse
+            $use_inflight_status ? $nagios[:status].parse : $nagios[:status_inflight].parse
+            $use_inflight_status = !$use_inflight_status
             sleep interval
           } #loop
         } # thread


### PR DESCRIPTION
Background parser will now flip the coin when its done parsing status file so http threads can  use refreshed copy with no delay. Coin never flips if background parser disabled. There is placeholder for objects file refresh, but since background parser is not set up to do this(needs different interval?) I'm skipping this step.
