### PR TITLE
[WIP] Enable/Disable service notifications

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -372,5 +372,5 @@ end
 
 require "app/routes/put/status"
 require "app/routes/put/host"
-require "app/routes/put/notifications"
+require "app/routes/put/notification"
 require "app/routes/put"

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -372,4 +372,5 @@ end
 
 require "app/routes/put/status"
 require "app/routes/put/host"
+require "app/routes/put/notifications"
 require "app/routes/put"

--- a/lib/app/routes/put.rb
+++ b/lib/app/routes/put.rb
@@ -49,5 +49,19 @@ class Nagira < Sinatra::Base
     def update_host_status params
       put_update :PROCESS_HOST_CHECK_RESULT, params
     end
+
+    # Small helper to submit data to ::Nagios::ExternalCommands
+    # object. For status updates sends external coond via
+    # ::Nagios::ExternalCommands.send method.
+    def disable_svc_notifications params
+      put_update :DISABLE_SVC_NOTIFICATIONS, params
+    end
+
+    # Small helper to submit data to ::Nagios::ExternalCommands
+    # object. For status updates sends external coond via
+    # ::Nagios::ExternalCommands.send method.
+    def enable_svc_notifications params
+      put_update :ENABLE_SVC_NOTIFICATIONS, params
+    end
   
 end

--- a/lib/app/routes/put/notification.rb
+++ b/lib/app/routes/put/notification.rb
@@ -1,0 +1,32 @@
+#
+# PUT method routes for notifications.
+#
+class Nagira < Sinatra::Base
+
+  put "/_notifications/:host_name/:service_description" do
+
+    data, result = [], true
+
+    @input.each do |datum|
+      update = {}
+      if datum['command'] == 'enable'
+        update = enable_svc_notifications(
+                    'host_name' => params['host_name'],
+                    'service_description' => params['service_description']
+                 )
+      end
+      elsif datum['command'] == 'disable'
+        update = disable_svc_notifications(
+                    'host_name' => params['host_name'],
+                    'service_description' => params['service_description']
+                 )
+      end
+      data << update[:object].first
+      result &&= update[:result]
+    end
+    @data = { result: result, object: data }
+    nil
+
+  end
+
+end

--- a/lib/app/routes/put/notification.rb
+++ b/lib/app/routes/put/notification.rb
@@ -14,7 +14,6 @@ class Nagira < Sinatra::Base
                     'host_name' => params['host_name'],
                     'service_description' => params['service_description']
                  )
-      end
       elsif datum['command'] == 'disable'
         update = disable_svc_notifications(
                     'host_name' => params['host_name'],


### PR DESCRIPTION
Hi, i'm a user of this awesome product, and use it for our production systems. 

I'd like to enable/disable service notification, and I tried to implement new feature in this PR. 
After merging this, we can enable/disable monitor like this:

``` bash
$ curl -X PUT 'http://example.com:4567/_notifications/host01/DISK' -d '{"command":"enable"}'
{"result":true,"object":[{"data":{"host_name":"host01","service_description":"DISK","action":"ENABLE_SVC_NOTIFICATIONS"},"result":true,"messages":[]}]}

$ curl -X PUT 'http://example.com:4567/_notifications/host01/DISK' -d '{"command":"disable"}'
{"result":true,"object":[{"data":{"host_name":"host01","service_description":"DISK","action":"DISABLE_SVC_NOTIFICATIONS"},"result":true,"messages":[]}]}
```

But I'm not sure whether this URI is proper or not. Could you tell me your thought? In addition, if I implement endpoint for other operation (e.g. enable/disable host notification), how should I implement it?

Of course, I'm ready for editing this PR.
Thanks in advance.
